### PR TITLE
Add a struct to represent a block.

### DIFF
--- a/lib/bsv/block.ex
+++ b/lib/bsv/block.ex
@@ -5,6 +5,8 @@ defmodule BSV.Block do
   use Bitwise
   alias BSV.Crypto.Hash
   alias BSV.Util
+  alias BSV.Util.VarBin
+  alias BSV.Transaction
 
   @enforce_keys [:version, :previous_block, :merkle_root, :timestamp, :bits, :nonce]
 
@@ -28,12 +30,17 @@ defmodule BSV.Block do
           timestamp: DateTime.t(),
           bits: binary(),
           nonce: binary(),
-          transactions: [binary()] | nil
+          transactions: [Transaction.t()] | nil
         }
 
   @doc """
   Parse the given binary into a block. Returns a tuple containing the
   parsed block and the remaining binary data.
+
+  ## Arguments
+
+  * `include_transactions` - will attempt to parse transactions that follow the block header in the
+     binary. Disabled by default.
 
   ## Options
 
@@ -47,32 +54,44 @@ defmodule BSV.Block do
     iex> {block, ""} = raw |> Base.decode16!() |> BSV.Block.parse()
     iex> Base.encode16(block.hash)
     "00000000839A8E6886AB5951D76F411475428AFC90947EE320161BBF18EB6048"
-    iex> {block, ""} = raw |> BSV.Block.parse(encoding: :hex)
+    iex> {block, ""} = raw |> BSV.Block.parse(false, encoding: :hex)
     iex> Base.encode16(block.hash)
     "00000000839A8E6886AB5951D76F411475428AFC90947EE320161BBF18EB6048"
   """
-  @spec parse(binary, keyword) :: {__MODULE__.t, binary}
-  def parse(data, options \\ []) do
+  @spec parse(binary, boolean, keyword) :: {__MODULE__.t(), binary}
+  def parse(data, include_transactions \\ false, options \\ []) do
     encoding = Keyword.get(options, :encoding)
 
     <<block_bytes::binary-size(80), rest::binary>> = data |> Util.decode(encoding)
+
     <<version::little-size(32), previous_block::binary-size(32), merkle_root::binary-size(32),
-          timestamp::little-size(32), bits::binary-size(4), nonce::binary-size(4)>> = block_bytes
+      timestamp::little-size(32), bits::binary-size(4), nonce::binary-size(4)>> = block_bytes
+
+    {transactions, rest} =
+      if include_transactions do
+        rest |> VarBin.parse_items(&Transaction.parse/1)
+      else
+        {nil, rest}
+      end
 
     {%__MODULE__{
-      hash: block_bytes |> Hash.sha256_sha256() |> Util.reverse_bin(),
-      version: version,
-      previous_block: previous_block |> Util.reverse_bin(),
-      merkle_root: merkle_root,
-      timestamp: DateTime.from_unix!(timestamp),
-      bits: bits,
-      nonce: nonce,
-      transactions: nil
-    }, rest}
+       hash: block_bytes |> Hash.sha256_sha256() |> Util.reverse_bin(),
+       version: version,
+       previous_block: previous_block |> Util.reverse_bin(),
+       merkle_root: merkle_root,
+       timestamp: DateTime.from_unix!(timestamp),
+       bits: bits,
+       nonce: nonce,
+       transactions: transactions
+     }, rest}
   end
 
   @doc """
   Serialises the given block into a binary.
+
+  ## Arguments
+
+  * `include_transactions` - will add transactions into the serialized binary. Disabled by default.
 
   ## Options
 
@@ -85,19 +104,30 @@ defmodule BSV.Block do
       BSV.Block.serialize(input)
       <<binary>>
   """
-  @spec serialize(__MODULE__.t, keyword) :: binary
-  def serialize(%__MODULE__{} = block, options \\ []) do
+  @spec serialize(__MODULE__.t(), boolean, keyword) :: binary
+  def serialize(block, include_transactions \\ false, options \\ [])
+
+  def serialize(%__MODULE__{} = block, false, options) do
     encoding = Keyword.get(options, :encoding)
 
     timestamp = DateTime.to_unix(block.timestamp)
-    (<<block.version::little-size(32)>> <>
-      (block.previous_block |> Util.reverse_bin()) <>
-      block.merkle_root <>
-      <<timestamp::little-size(32)>> <>
-      block.bits <>
-      block.nonce)
-      |> Util.encode(encoding)
 
+    (<<block.version::little-size(32)>> <>
+       (block.previous_block |> Util.reverse_bin()) <>
+       block.merkle_root <>
+       <<timestamp::little-size(32)>> <>
+       block.bits <>
+       block.nonce)
+    |> Util.encode(encoding)
+  end
+
+  def serialize(%__MODULE__{transactions: transactions} = block, true, options)
+      when is_list(transactions) do
+    encoding = Keyword.get(options, :encoding)
+
+    (serialize(block, false) <>
+       (transactions |> VarBin.serialize_items(&Transaction.serialize/1)))
+    |> Util.encode(encoding)
   end
 
   @doc """
@@ -106,7 +136,7 @@ defmodule BSV.Block do
   Examples
 
     iex> raw = "010000006FE28C0AB6F1B372C1A6A246AE63F74F931E8365E15A089C68D6190000000000982051FD1E4BA744BBBE680E1FEE14677BA1A3C3540BF7B1CDB606E857233E0E61BC6649FFFF001D01E36299"
-    iex> {block, ""} = BSV.Block.parse(raw, encoding: :hex)
+    iex> {block, ""} = BSV.Block.parse(raw, false, encoding: :hex)
     iex> BSV.Block.id(block)
     "00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048"
   """
@@ -131,7 +161,7 @@ defmodule BSV.Block do
   ## Examples
 
     iex> raw = "010000006FE28C0AB6F1B372C1A6A246AE63F74F931E8365E15A089C68D6190000000000982051FD1E4BA744BBBE680E1FEE14677BA1A3C3540BF7B1CDB606E857233E0E61BC6649FFFF001D01E36299"
-    iex> {block, ""} = BSV.Block.parse(raw, encoding: :hex)
+    iex> {block, ""} = BSV.Block.parse(raw, false, encoding: :hex)
     iex> BSV.Block.hash(block)
     <<0, 0, 0, 0, 131, 154, 142, 104, 134, 171, 89, 81, 215, 111, 65, 20, 117, 66, 138, 252, 144, 148, 126, 227, 32, 22, 27, 191, 24, 235, 96, 72>>
   """
@@ -155,7 +185,7 @@ defmodule BSV.Block do
   Examples
 
     iex> raw = "010000006FE28C0AB6F1B372C1A6A246AE63F74F931E8365E15A089C68D6190000000000982051FD1E4BA744BBBE680E1FEE14677BA1A3C3540BF7B1CDB606E857233E0E61BC6649FFFF001D01E36299"
-    iex> {block, ""} = BSV.Block.parse(raw, encoding: :hex)
+    iex> {block, ""} = BSV.Block.parse(raw, false, encoding: :hex)
     iex> BSV.Block.previous_id(block)
     "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
   """

--- a/lib/bsv/block.ex
+++ b/lib/bsv/block.ex
@@ -1,0 +1,166 @@
+defmodule BSV.Block do
+  @moduledoc """
+  Module for the construction, parsing and serialization of Bitcoin block headers.
+  """
+  use Bitwise
+  alias BSV.Crypto.Hash
+  alias BSV.Util
+
+  @enforce_keys [:version, :previous_block, :merkle_root, :timestamp, :bits, :nonce]
+
+  @typedoc "A Bitcoin block."
+  defstruct [
+    :hash,
+    :version,
+    :previous_block,
+    :merkle_root,
+    :timestamp,
+    :bits,
+    :nonce,
+    :transactions
+  ]
+
+  @type t :: %__MODULE__{
+          hash: binary() | nil,
+          version: non_neg_integer(),
+          previous_block: binary(),
+          merkle_root: binary(),
+          timestamp: DateTime.t(),
+          bits: binary(),
+          nonce: binary(),
+          transactions: [binary()] | nil
+        }
+
+  @doc """
+  Parse the given binary into a block. Returns a tuple containing the
+  parsed block and the remaining binary data.
+
+  ## Options
+
+  The accepted options are:
+
+  * `:encoding` - Optionally decode the binary with either the `:base64` or `:hex` encoding scheme.
+
+  ## Examples
+
+    iex> raw = "010000006FE28C0AB6F1B372C1A6A246AE63F74F931E8365E15A089C68D6190000000000982051FD1E4BA744BBBE680E1FEE14677BA1A3C3540BF7B1CDB606E857233E0E61BC6649FFFF001D01E36299"
+    iex> {block, ""} = raw |> Base.decode16!() |> BSV.Block.parse()
+    iex> Base.encode16(block.hash)
+    "00000000839A8E6886AB5951D76F411475428AFC90947EE320161BBF18EB6048"
+    iex> {block, ""} = raw |> BSV.Block.parse(encoding: :hex)
+    iex> Base.encode16(block.hash)
+    "00000000839A8E6886AB5951D76F411475428AFC90947EE320161BBF18EB6048"
+  """
+  @spec parse(binary, keyword) :: {__MODULE__.t, binary}
+  def parse(data, options \\ []) do
+    encoding = Keyword.get(options, :encoding)
+
+    <<block_bytes::binary-size(80), rest::binary>> = data |> Util.decode(encoding)
+    <<version::little-size(32), previous_block::binary-size(32), merkle_root::binary-size(32),
+          timestamp::little-size(32), bits::binary-size(4), nonce::binary-size(4)>> = block_bytes
+
+    {%__MODULE__{
+      hash: block_bytes |> Hash.sha256_sha256() |> Util.reverse_bin(),
+      version: version,
+      previous_block: previous_block |> Util.reverse_bin(),
+      merkle_root: merkle_root,
+      timestamp: DateTime.from_unix!(timestamp),
+      bits: bits,
+      nonce: nonce,
+      transactions: nil
+    }, rest}
+  end
+
+  @doc """
+  Serialises the given block into a binary.
+
+  ## Options
+
+  The accepted options are:
+
+  * `:encode` - Optionally encode the returned binary with either the `:base64` or `:hex` encoding scheme.
+
+  ## Examples
+
+      BSV.Block.serialize(input)
+      <<binary>>
+  """
+  @spec serialize(__MODULE__.t, keyword) :: binary
+  def serialize(%__MODULE__{} = block, options \\ []) do
+    encoding = Keyword.get(options, :encoding)
+
+    timestamp = DateTime.to_unix(block.timestamp)
+    (<<block.version::little-size(32)>> <>
+      (block.previous_block |> Util.reverse_bin()) <>
+      block.merkle_root <>
+      <<timestamp::little-size(32)>> <>
+      block.bits <>
+      block.nonce)
+      |> Util.encode(encoding)
+
+  end
+
+  @doc """
+  Gets the block id (hash in the hex form).
+
+  Examples
+
+    iex> raw = "010000006FE28C0AB6F1B372C1A6A246AE63F74F931E8365E15A089C68D6190000000000982051FD1E4BA744BBBE680E1FEE14677BA1A3C3540BF7B1CDB606E857233E0E61BC6649FFFF001D01E36299"
+    iex> {block, ""} = BSV.Block.parse(raw, encoding: :hex)
+    iex> BSV.Block.id(block)
+    "00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048"
+  """
+  @spec id(__MODULE__.t()) :: String.t()
+  def id(block) do
+    case block.hash do
+      nil ->
+        block
+        |> serialize()
+        |> Hash.sha256_sha256()
+        |> Util.reverse_bin()
+        |> Util.encode(:hex)
+
+      _ ->
+        Util.encode(block.hash, :hex)
+    end
+  end
+
+  @doc """
+  Gets the block hash.
+
+  ## Examples
+
+    iex> raw = "010000006FE28C0AB6F1B372C1A6A246AE63F74F931E8365E15A089C68D6190000000000982051FD1E4BA744BBBE680E1FEE14677BA1A3C3540BF7B1CDB606E857233E0E61BC6649FFFF001D01E36299"
+    iex> {block, ""} = BSV.Block.parse(raw, encoding: :hex)
+    iex> BSV.Block.hash(block)
+    <<0, 0, 0, 0, 131, 154, 142, 104, 134, 171, 89, 81, 215, 111, 65, 20, 117, 66, 138, 252, 144, 148, 126, 227, 32, 22, 27, 191, 24, 235, 96, 72>>
+  """
+  @spec hash(__MODULE__.t()) :: binary()
+  def hash(transaction) do
+    case transaction.hash do
+      nil ->
+        transaction
+        |> serialize()
+        |> Hash.sha256_sha256()
+        |> Util.reverse_bin()
+
+      _ ->
+        transaction.hash
+    end
+  end
+
+  @doc """
+  Gets the previous block id.
+
+  Examples
+
+    iex> raw = "010000006FE28C0AB6F1B372C1A6A246AE63F74F931E8365E15A089C68D6190000000000982051FD1E4BA744BBBE680E1FEE14677BA1A3C3540BF7B1CDB606E857233E0E61BC6649FFFF001D01E36299"
+    iex> {block, ""} = BSV.Block.parse(raw, encoding: :hex)
+    iex> BSV.Block.previous_id(block)
+    "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+  """
+  @spec previous_id(__MODULE__.t()) :: String.t()
+  def previous_id(block) do
+    block.previous_block |> Util.encode(:hex)
+  end
+end

--- a/test/bsv/block_test.exs
+++ b/test/bsv/block_test.exs
@@ -1,21 +1,75 @@
 defmodule BSV.BlockTest do
   use ExUnit.Case
-  alias BSV.Block
-  alias BSV.Util
+  alias BSV.{Block, Util, Transaction}
   doctest BSV.Block
 
   test "parse/2 with extra data" do
     {block, <<0xFF, 0xEE>>} =
       Block.parse(
         "010000006FE28C0AB6F1B372C1A6A246AE63F74F931E8365E15A089C68D6190000000000982051FD1E4BA744BBBE680E1FEE14677BA1A3C3540BF7B1CDB606E857233E0E61BC6649FFFF001D01E36299FFEE",
+        false,
         encoding: :hex
       )
 
     assert Util.encode(block.hash, :hex) ==
              "00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048"
+
+    assert block.transactions == nil
   end
 
-  test "serialize/1 " do
+  test "parse/2 with transactions" do
+    {block, <<0xFF, 0xEE>>} =
+      Block.parse(
+        "010000006FE28C0AB6F1B372C1A6A246AE63F74F931E8365E15A089C68D6190000000000982051FD1E4BA744BBBE680E1FEE14677BA1A3C3540BF7B1CDB606E857233E0E61BC6649FFFF001D01E362990101000000010000000000000000000000000000000000000000000000000000000000000000FFFFFFFF0704FFFF001D0104FFFFFFFF0100F2052A0100000043410496B538E853519C726A2C91E61EC11600AE1390813A627C66FB8BE7947BE63C52DA7589379515D4E0A604F8141781E62294721166BF621E73A82CBF2342C858EEAC00000000FFEE",
+        true,
+        encoding: :hex
+      )
+
+    assert Util.encode(block.hash, :hex) ==
+             "00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048"
+
+    assert length(block.transactions) == 1
+
+    assert hd(block.transactions) |> Transaction.get_txid() ==
+             "0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098"
+  end
+
+  test "parse/2 without transactions using blob that includes them" do
+    {block, rest} =
+      Block.parse(
+        "010000006FE28C0AB6F1B372C1A6A246AE63F74F931E8365E15A089C68D6190000000000982051FD1E4BA744BBBE680E1FEE14677BA1A3C3540BF7B1CDB606E857233E0E61BC6649FFFF001D01E362990101000000010000000000000000000000000000000000000000000000000000000000000000FFFFFFFF0704FFFF001D0104FFFFFFFF0100F2052A0100000043410496B538E853519C726A2C91E61EC11600AE1390813A627C66FB8BE7947BE63C52DA7589379515D4E0A604F8141781E62294721166BF621E73A82CBF2342C858EEAC00000000FFEE",
+        false,
+        encoding: :hex
+      )
+
+    assert Util.encode(rest, :hex) ==
+             "0101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d0104ffffffff0100f2052a0100000043410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac00000000ffee"
+
+    assert Util.encode(block.hash, :hex) ==
+             "00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048"
+
+    assert block.transactions == nil
+  end
+
+  test "parse/2 transactions but with blob that does not include them" do
+    assert_raise FunctionClauseError, fn ->
+      Block.parse(
+        "010000006FE28C0AB6F1B372C1A6A246AE63F74F931E8365E15A089C68D6190000000000982051FD1E4BA744BBBE680E1FEE14677BA1A3C3540BF7B1CDB606E857233E0E61BC6649FFFF001D01E36299",
+        true,
+        encoding: :hex
+      )
+    end
+
+    assert_raise MatchError, fn ->
+      Block.parse(
+        "010000006FE28C0AB6F1B372C1A6A246AE63F74F931E8365E15A089C68D6190000000000982051FD1E4BA744BBBE680E1FEE14677BA1A3C3540BF7B1CDB606E857233E0E61BC6649FFFF001D01E36299FFEE",
+        true,
+        encoding: :hex
+      )
+    end
+  end
+
+  test "serialize/1" do
     binary_block =
       Util.decode(
         "010000006FE28C0AB6F1B372C1A6A246AE63F74F931E8365E15A089C68D6190000000000982051FD1E4BA744BBBE680E1FEE14677BA1A3C3540BF7B1CDB606E857233E0E61BC6649FFFF001D01E36299",
@@ -33,12 +87,157 @@ defmodule BSV.BlockTest do
                    161, 163, 195, 84, 11, 247, 177, 205, 182, 6, 232, 87, 35, 62, 14>>,
                nonce: <<1, 227, 98, 153>>,
                previous_block:
-                 <<0, 0, 0, 0, 0, 25, 214, 104, 156, 8, 90, 225, 101, 131, 30, 147, 79, 247,
-                   99, 174, 70, 162, 166, 193, 114, 179, 241, 182, 10, 140, 226, 111>>,
+                 <<0, 0, 0, 0, 0, 25, 214, 104, 156, 8, 90, 225, 101, 131, 30, 147, 79, 247, 99,
+                   174, 70, 162, 166, 193, 114, 179, 241, 182, 10, 140, 226, 111>>,
                timestamp: ~U[2009-01-09 02:54:25Z],
                transactions: nil,
                version: 1
              })
+  end
+
+  test "serialize/1 with transactions" do
+    binary_block =
+      Util.decode(
+        "010000006FE28C0AB6F1B372C1A6A246AE63F74F931E8365E15A089C68D6190000000000982051FD1E4BA744BBBE680E1FEE14677BA1A3C3540BF7B1CDB606E857233E0E61BC6649FFFF001D01E362990101000000010000000000000000000000000000000000000000000000000000000000000000FFFFFFFF0704FFFF001D0104FFFFFFFF0100F2052A0100000043410496B538E853519C726A2C91E61EC11600AE1390813A627C66FB8BE7947BE63C52DA7589379515D4E0A604F8141781E62294721166BF621E73A82CBF2342C858EEAC00000000",
+        :hex
+      )
+
+    parsed_block = %BSV.Block{
+      bits: <<255, 255, 0, 29>>,
+      hash:
+        <<0, 0, 0, 0, 131, 154, 142, 104, 134, 171, 89, 81, 215, 111, 65, 20, 117, 66, 138, 252,
+          144, 148, 126, 227, 32, 22, 27, 191, 24, 235, 96, 72>>,
+      merkle_root:
+        <<152, 32, 81, 253, 30, 75, 167, 68, 187, 190, 104, 14, 31, 238, 20, 103, 123, 161, 163,
+          195, 84, 11, 247, 177, 205, 182, 6, 232, 87, 35, 62, 14>>,
+      nonce: <<1, 227, 98, 153>>,
+      previous_block:
+        <<0, 0, 0, 0, 0, 25, 214, 104, 156, 8, 90, 225, 101, 131, 30, 147, 79, 247, 99, 174, 70,
+          162, 166, 193, 114, 179, 241, 182, 10, 140, 226, 111>>,
+      timestamp: ~U[2009-01-09 02:54:25Z],
+      transactions: [
+        %BSV.Transaction{
+          change_index: nil,
+          change_script: nil,
+          fee: nil,
+          inputs: [
+            %BSV.Transaction.Input{
+              output_index: 4_294_967_295,
+              output_txid: "0000000000000000000000000000000000000000000000000000000000000000",
+              script: %BSV.Script{chunks: [<<255, 255, 0, 29>>, <<4>>]},
+              sequence: 4_294_967_295,
+              utxo: nil
+            }
+          ],
+          lock_time: 0,
+          outputs: [
+            %BSV.Transaction.Output{
+              satoshis: 5_000_000_000,
+              script: %BSV.Script{
+                chunks: [
+                  <<4, 150, 181, 56, 232, 83, 81, 156, 114, 106, 44, 145, 230, 30, 193, 22, 0,
+                    174, 19, 144, 129, 58, 98, 124, 102, 251, 139, 231, 148, 123, 230, 60, 82,
+                    218, 117, 137, 55, 149, 21, 212, 224, 166, 4, 248, 20, 23, 129, 230, 34, 148,
+                    114, 17, 102, 191, 98, 30, 115, 168, 44, 191, 35, 66, 200, 88, 238>>,
+                  :OP_CHECKSIG
+                ]
+              }
+            }
+          ],
+          version: 1
+        }
+      ],
+      version: 1
+    }
+
+    assert binary_block == Block.serialize(parsed_block, true)
+    assert Util.encode(binary_block, :hex) == Block.serialize(parsed_block, true, encoding: :hex)
+
+    assert Util.encode(binary_block, :base64) ==
+             Block.serialize(parsed_block, true, encoding: :base64)
+  end
+
+  test "serialize/1 without transactions using struct that includes them" do
+    binary_block =
+      Util.decode(
+        "010000006FE28C0AB6F1B372C1A6A246AE63F74F931E8365E15A089C68D6190000000000982051FD1E4BA744BBBE680E1FEE14677BA1A3C3540BF7B1CDB606E857233E0E61BC6649FFFF001D01E36299",
+        :hex
+      )
+
+    assert binary_block ==
+             Block.serialize(%BSV.Block{
+               bits: <<255, 255, 0, 29>>,
+               hash:
+                 <<0, 0, 0, 0, 131, 154, 142, 104, 134, 171, 89, 81, 215, 111, 65, 20, 117, 66,
+                   138, 252, 144, 148, 126, 227, 32, 22, 27, 191, 24, 235, 96, 72>>,
+               merkle_root:
+                 <<152, 32, 81, 253, 30, 75, 167, 68, 187, 190, 104, 14, 31, 238, 20, 103, 123,
+                   161, 163, 195, 84, 11, 247, 177, 205, 182, 6, 232, 87, 35, 62, 14>>,
+               nonce: <<1, 227, 98, 153>>,
+               previous_block:
+                 <<0, 0, 0, 0, 0, 25, 214, 104, 156, 8, 90, 225, 101, 131, 30, 147, 79, 247, 99,
+                   174, 70, 162, 166, 193, 114, 179, 241, 182, 10, 140, 226, 111>>,
+               timestamp: ~U[2009-01-09 02:54:25Z],
+               transactions: [
+                 %BSV.Transaction{
+                   change_index: nil,
+                   change_script: nil,
+                   fee: nil,
+                   inputs: [
+                     %BSV.Transaction.Input{
+                       output_index: 4_294_967_295,
+                       output_txid:
+                         "0000000000000000000000000000000000000000000000000000000000000000",
+                       script: %BSV.Script{chunks: [<<255, 255, 0, 29>>, <<4>>]},
+                       sequence: 4_294_967_295,
+                       utxo: nil
+                     }
+                   ],
+                   lock_time: 0,
+                   outputs: [
+                     %BSV.Transaction.Output{
+                       satoshis: 5_000_000_000,
+                       script: %BSV.Script{
+                         chunks: [
+                           <<4, 150, 181, 56, 232, 83, 81, 156, 114, 106, 44, 145, 230, 30, 193,
+                             22, 0, 174, 19, 144, 129, 58, 98, 124, 102, 251, 139, 231, 148, 123,
+                             230, 60, 82, 218, 117, 137, 55, 149, 21, 212, 224, 166, 4, 248, 20,
+                             23, 129, 230, 34, 148, 114, 17, 102, 191, 98, 30, 115, 168, 44, 191,
+                             35, 66, 200, 88, 238>>,
+                           :OP_CHECKSIG
+                         ]
+                       }
+                     }
+                   ],
+                   version: 1
+                 }
+               ],
+               version: 1
+             })
+  end
+
+  test "serialize/1 with transactions but struct without them fails" do
+    assert_raise FunctionClauseError, fn ->
+      Block.serialize(
+        %BSV.Block{
+          bits: <<255, 255, 0, 29>>,
+          hash:
+            <<0, 0, 0, 0, 131, 154, 142, 104, 134, 171, 89, 81, 215, 111, 65, 20, 117, 66, 138,
+              252, 144, 148, 126, 227, 32, 22, 27, 191, 24, 235, 96, 72>>,
+          merkle_root:
+            <<152, 32, 81, 253, 30, 75, 167, 68, 187, 190, 104, 14, 31, 238, 20, 103, 123, 161,
+              163, 195, 84, 11, 247, 177, 205, 182, 6, 232, 87, 35, 62, 14>>,
+          nonce: <<1, 227, 98, 153>>,
+          previous_block:
+            <<0, 0, 0, 0, 0, 25, 214, 104, 156, 8, 90, 225, 101, 131, 30, 147, 79, 247, 99, 174,
+              70, 162, 166, 193, 114, 179, 241, 182, 10, 140, 226, 111>>,
+          timestamp: ~U[2009-01-09 02:54:25Z],
+          transactions: nil,
+          version: 1
+        },
+        true
+      )
+    end
   end
 
   test "hash/1 without the pre-computed hash" do
@@ -51,8 +250,8 @@ defmodule BSV.BlockTest do
             195, 84, 11, 247, 177, 205, 182, 6, 232, 87, 35, 62, 14>>,
         nonce: <<1, 227, 98, 153>>,
         previous_block:
-          <<0, 0, 0, 0, 0, 25, 214, 104, 156, 8, 90, 225, 101, 131, 30, 147, 79, 247,
-            99, 174, 70, 162, 166, 193, 114, 179, 241, 182, 10, 140, 226, 111>>,
+          <<0, 0, 0, 0, 0, 25, 214, 104, 156, 8, 90, 225, 101, 131, 30, 147, 79, 247, 99, 174, 70,
+            162, 166, 193, 114, 179, 241, 182, 10, 140, 226, 111>>,
         timestamp: ~U[2009-01-09 02:54:25Z],
         transactions: nil,
         version: 1
@@ -73,8 +272,8 @@ defmodule BSV.BlockTest do
             195, 84, 11, 247, 177, 205, 182, 6, 232, 87, 35, 62, 14>>,
         nonce: <<1, 227, 98, 153>>,
         previous_block:
-          <<0, 0, 0, 0, 0, 25, 214, 104, 156, 8, 90, 225, 101, 131, 30, 147, 79, 247,
-            99, 174, 70, 162, 166, 193, 114, 179, 241, 182, 10, 140, 226, 111>>,
+          <<0, 0, 0, 0, 0, 25, 214, 104, 156, 8, 90, 225, 101, 131, 30, 147, 79, 247, 99, 174, 70,
+            162, 166, 193, 114, 179, 241, 182, 10, 140, 226, 111>>,
         timestamp: ~U[2009-01-09 02:54:25Z],
         transactions: nil,
         version: 1

--- a/test/bsv/block_test.exs
+++ b/test/bsv/block_test.exs
@@ -1,0 +1,85 @@
+defmodule BSV.BlockTest do
+  use ExUnit.Case
+  alias BSV.Block
+  alias BSV.Util
+  doctest BSV.Block
+
+  test "parse/2 with extra data" do
+    {block, <<0xFF, 0xEE>>} =
+      Block.parse(
+        "010000006FE28C0AB6F1B372C1A6A246AE63F74F931E8365E15A089C68D6190000000000982051FD1E4BA744BBBE680E1FEE14677BA1A3C3540BF7B1CDB606E857233E0E61BC6649FFFF001D01E36299FFEE",
+        encoding: :hex
+      )
+
+    assert Util.encode(block.hash, :hex) ==
+             "00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048"
+  end
+
+  test "serialize/1 " do
+    binary_block =
+      Util.decode(
+        "010000006FE28C0AB6F1B372C1A6A246AE63F74F931E8365E15A089C68D6190000000000982051FD1E4BA744BBBE680E1FEE14677BA1A3C3540BF7B1CDB606E857233E0E61BC6649FFFF001D01E36299",
+        :hex
+      )
+
+    assert binary_block ==
+             Block.serialize(%Block{
+               bits: <<255, 255, 0, 29>>,
+               hash:
+                 <<0, 0, 0, 0, 131, 154, 142, 104, 134, 171, 89, 81, 215, 111, 65, 20, 117, 66,
+                   138, 252, 144, 148, 126, 227, 32, 22, 27, 191, 24, 235, 96, 72>>,
+               merkle_root:
+                 <<152, 32, 81, 253, 30, 75, 167, 68, 187, 190, 104, 14, 31, 238, 20, 103, 123,
+                   161, 163, 195, 84, 11, 247, 177, 205, 182, 6, 232, 87, 35, 62, 14>>,
+               nonce: <<1, 227, 98, 153>>,
+               previous_block:
+                 <<0, 0, 0, 0, 0, 25, 214, 104, 156, 8, 90, 225, 101, 131, 30, 147, 79, 247,
+                   99, 174, 70, 162, 166, 193, 114, 179, 241, 182, 10, 140, 226, 111>>,
+               timestamp: ~U[2009-01-09 02:54:25Z],
+               transactions: nil,
+               version: 1
+             })
+  end
+
+  test "hash/1 without the pre-computed hash" do
+    hash =
+      Block.hash(%Block{
+        bits: <<255, 255, 0, 29>>,
+        hash: nil,
+        merkle_root:
+          <<152, 32, 81, 253, 30, 75, 167, 68, 187, 190, 104, 14, 31, 238, 20, 103, 123, 161, 163,
+            195, 84, 11, 247, 177, 205, 182, 6, 232, 87, 35, 62, 14>>,
+        nonce: <<1, 227, 98, 153>>,
+        previous_block:
+          <<0, 0, 0, 0, 0, 25, 214, 104, 156, 8, 90, 225, 101, 131, 30, 147, 79, 247,
+            99, 174, 70, 162, 166, 193, 114, 179, 241, 182, 10, 140, 226, 111>>,
+        timestamp: ~U[2009-01-09 02:54:25Z],
+        transactions: nil,
+        version: 1
+      })
+
+    assert hash ==
+             <<0, 0, 0, 0, 131, 154, 142, 104, 134, 171, 89, 81, 215, 111, 65, 20, 117, 66, 138,
+               252, 144, 148, 126, 227, 32, 22, 27, 191, 24, 235, 96, 72>>
+  end
+
+  test "id/1 without the pre-computed hash" do
+    id =
+      Block.id(%Block{
+        bits: <<255, 255, 0, 29>>,
+        hash: nil,
+        merkle_root:
+          <<152, 32, 81, 253, 30, 75, 167, 68, 187, 190, 104, 14, 31, 238, 20, 103, 123, 161, 163,
+            195, 84, 11, 247, 177, 205, 182, 6, 232, 87, 35, 62, 14>>,
+        nonce: <<1, 227, 98, 153>>,
+        previous_block:
+          <<0, 0, 0, 0, 0, 25, 214, 104, 156, 8, 90, 225, 101, 131, 30, 147, 79, 247,
+            99, 174, 70, 162, 166, 193, 114, 179, 241, 182, 10, 140, 226, 111>>,
+        timestamp: ~U[2009-01-09 02:54:25Z],
+        transactions: nil,
+        version: 1
+      })
+
+    assert id == "00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048"
+  end
+end


### PR DESCRIPTION
Comes from [slashrsm/bsv_rpc](https://github.com/slashrsm/bsv_rpc).