### PR TITLE
Make sure that coinbase transactions are parsed correctly

### DIFF
--- a/lib/bsv/transaction.ex
+++ b/lib/bsv/transaction.ex
@@ -381,6 +381,9 @@ defmodule BSV.Transaction do
   def sign(%__MODULE__{} = tx, keys) when is_list(keys),
     do: keys |> Enum.reduce(tx, &(sign(&2, &1)))
 
+  @spec is_coinbase(__MODULE__.t()) :: boolean
+  def is_coinbase(%__MODULE__{inputs: [first_input | _] = inputs}), do:
+    length(inputs) == 1 and Input.is_null(first_input)
 
   # Needs to be called every time a change is made to inputs or outputs
   defp update_change_output(%__MODULE__{change_script: script} = tx)

--- a/lib/bsv/transaction/input.ex
+++ b/lib/bsv/transaction/input.ex
@@ -50,10 +50,12 @@ defmodule BSV.Transaction.Input do
     {script, data} = VarBin.parse_bin(data)
     <<sequence::little-32, data::binary>> = data
 
+    txid = txid |> Util.reverse_bin |> Util.encode(:hex)
+
     {struct(__MODULE__, [
-      output_txid: txid |> Util.reverse_bin |> Util.encode(:hex),
+      output_txid: txid,
       output_index: index,
-      script: Script.parse(script),
+      script: (if is_null(txid, index), do: Script.get_coinbase(script), else: Script.parse(script)),
       sequence: sequence
     ]), data}
   end
@@ -107,6 +109,30 @@ defmodule BSV.Transaction.Input do
       %Script{chunks: []} -> 40 + @p2pkh_script_size
       _ -> serialize(tx) |> byte_size
     end
+  end
+
+  @doc """
+  Gets whether this is a null input (coinbase transaction input).
+
+  ## Examples
+
+    iex> {%BSV.Transaction{inputs: [coinbase_input]}, ""} = BSV.Transaction.parse("01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d0104ffffffff0100f2052a0100000043410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac00000000", encoding: :hex)
+    iex> BSV.Transaction.Input.is_null(coinbase_input)
+    true
+
+    iex> {%BSV.Transaction{inputs: [input]}, ""} = BSV.Transaction.parse("0100000001ae13d3386c0541b9f8528c7f215713e94c52279318090a95e39e5b123360ee48110000006a47304402206d0cf8f9ac8cadcb5061072ff28ca434620bbb0d442f9578d560e840a9cce90a022023aaae374be08838cb42cafd35459f140c6b440db45e6ecc007d9d5d95c89d504121036ce3ac90505e8ca49c0f43d5db1ebf67dc502d79518db2ab54e86947ab1c91fefeffffff01a0aae219020000001976a914ab1cad2d09eedfb15794cc01edc2141b7ccc587388ac77d50900", encoding: :hex)
+    iex> BSV.Transaction.Input.is_null(input)
+    false
+
+  """
+  @spec is_null(__MODULE__.t) :: boolean
+  def is_null(%__MODULE__{output_txid: transaction, output_index: index}) do
+    is_null(transaction, index)
+  end
+
+  @spec is_null(String.t(), non_neg_integer) :: boolean
+  defp is_null(previous_transaction, previous_index) do
+    previous_transaction == "0000000000000000000000000000000000000000000000000000000000000000" and previous_index == 0xFFFFFFFF
   end
 
 end

--- a/test/bsv/script_test.exs
+++ b/test/bsv/script_test.exs
@@ -1,5 +1,21 @@
 defmodule BSV.ScriptTest do
   use ExUnit.Case
+  alias BSV.Script
   doctest BSV.Script
 
+  test "serialize/2 works with coinbase script" do
+    assert "keep calm and BSV on" == Script.serialize(%Script{coinbase: "keep calm and BSV on"})
+  end
+
+  test "serialize/2 fails if both chunks and coinbase are set" do
+    assert_raise FunctionClauseError, fn ->
+      Script.serialize(%Script{coinbase: "keep calm and BSV on", chunks: [:OP_1]})
+    end
+  end
+
+  test "is_coinbase/1 fails if both chunks and coinbase are set" do
+    assert_raise FunctionClauseError, fn ->
+      Script.is_coinbase(%Script{coinbase: "keep calm and BSV on", chunks: [:OP_1]})
+    end
+  end
 end

--- a/test/bsv/transaction_test.exs
+++ b/test/bsv/transaction_test.exs
@@ -1,11 +1,13 @@
 defmodule BSV.TransactionTest do
   use ExUnit.Case
   doctest BSV.Transaction
+  alias BSV.Script
   alias BSV.Transaction.{Input, Output}
 
   setup_all do
     %{
-      tx1: "02000000027bb22176433bb45bacede86a43764f98c7023f1a79b00138e3d3ea610716a8f1010000006b483045022100c7036739f47361398bd115dbe9302fdc456d75f83fb38e531f4a445c8385138a022006f68ca095a35886f3eb217f416650490a3f0a279f8dc564d0222c884002f85841210232b357c5309644cf4aa72b9b2d8bfe58bdf2515d40119318d5cb51ef378cae7effffffff197725400c9846a19a03cfd151bd089b9ec3e90ecbfa72b9c5448d52b2baae43020000006b483045022100b23044350aaaafb08480fee7addadde918c2b5515b66a3c445be05ca809ce290022044c89daa88303522cb72830ab71d1411da65f0a58dca43fcd998f80df3794cc441210282d7e568e56f59e01a4edae297ac26caabc4684971ac6c7558c91c0fa84002f7ffffffff03efbee82f000000001976a914c4263eb96d88849f498d139424b59a0cba1005e888ac010c1dfa000000001976a9146cbff9881ac47da8cb699e4543c28f9b3d6941da88ac404b4c00000000001976a914f7899faf1696892e6cb029b00c713f044761f03588ac00000000"
+      tx1: "02000000027bb22176433bb45bacede86a43764f98c7023f1a79b00138e3d3ea610716a8f1010000006b483045022100c7036739f47361398bd115dbe9302fdc456d75f83fb38e531f4a445c8385138a022006f68ca095a35886f3eb217f416650490a3f0a279f8dc564d0222c884002f85841210232b357c5309644cf4aa72b9b2d8bfe58bdf2515d40119318d5cb51ef378cae7effffffff197725400c9846a19a03cfd151bd089b9ec3e90ecbfa72b9c5448d52b2baae43020000006b483045022100b23044350aaaafb08480fee7addadde918c2b5515b66a3c445be05ca809ce290022044c89daa88303522cb72830ab71d1411da65f0a58dca43fcd998f80df3794cc441210282d7e568e56f59e01a4edae297ac26caabc4684971ac6c7558c91c0fa84002f7ffffffff03efbee82f000000001976a914c4263eb96d88849f498d139424b59a0cba1005e888ac010c1dfa000000001976a9146cbff9881ac47da8cb699e4543c28f9b3d6941da88ac404b4c00000000001976a914f7899faf1696892e6cb029b00c713f044761f03588ac00000000",
+      coinbase_tx1: "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff1d0379d5092f7376706f6f6c2e636f6d2f30e77996fe42f03db5bf080100ffffffff0163a64e25000000001976a91468888423f412b6b4166d61fe9e66a1aeff30df1f88ac00000000"
     }
   end
 
@@ -15,6 +17,23 @@ defmodule BSV.TransactionTest do
       {tx, ""} = BSV.Transaction.parse(ctx.tx1, encoding: :hex)
       assert length(tx.inputs) == 2
       assert length(tx.outputs) == 3
+      assert BSV.Transaction.is_coinbase(tx) == false
+
+      Enum.each(tx.inputs, fn input ->
+        assert Input.is_null(input) == false
+        assert input.script.coinbase == nil
+      end)
+    end
+
+    test "suceeds with a coinbase transaction", ctx do
+      {tx, ""} = BSV.Transaction.parse(ctx.coinbase_tx1, encoding: :hex)
+      assert BSV.Transaction.is_coinbase(tx) == true
+      assert length(tx.inputs) == 1
+      assert length(tx.outputs) == 1
+
+      [input] = tx.inputs
+      assert Input.is_null(input) == true
+      assert input.script == %Script{coinbase: "\x03y\xD5\t/svpool.com/0\xE7y\x96\xFEB\xF0=\xB5\xBF\b\x01\0", chunks: []}
     end
   end
 

--- a/test/bsv/transaction_test.exs
+++ b/test/bsv/transaction_test.exs
@@ -17,7 +17,7 @@ defmodule BSV.TransactionTest do
       {tx, ""} = BSV.Transaction.parse(ctx.tx1, encoding: :hex)
       assert length(tx.inputs) == 2
       assert length(tx.outputs) == 3
-      assert BSV.Transaction.is_coinbase(tx) == false
+       assert BSV.Transaction.is_coinbase(tx) == false
 
       Enum.each(tx.inputs, fn input ->
         assert Input.is_null(input) == false


### PR DESCRIPTION
Currently some coinbase transactions won't parse (Example is [8e77201327](https://whatsonchain.com/tx/8e77201327d9c0f933571ece462d905b725c0b72ca5a3ba6d47866cc1cd2068c) from block [#644473](https://whatsonchain.com/block-height/644473)). 

I suggest to add some logic to differentiate coinbase transactions/inputs/scripts from the rest of them. Approach that is implemented here follows the logic used in [moneybutton/bsv](https://github.com/moneybutton/bsv) - [[1]](https://github.com/moneybutton/bsv/blob/8817e22ab10f9ddd7a935f1c3a39bf327c663b06/lib/tx.js#L382), [[2]](https://github.com/moneybutton/bsv/blob/8817e22ab10f9ddd7a935f1c3a39bf327c663b06/lib/tx-in.js#L121).

In the script part I added a new struct element to allow us to differentiate coinbase on that level. Another option would be to store the coinbase data as a single  chunk, but in that case it would be harder to detect it. And I figured that being able to do that might be useful.